### PR TITLE
Update for Magento 2.4.2 compatibility

### DIFF
--- a/src/Block/Category/View.php
+++ b/src/Block/Category/View.php
@@ -133,7 +133,7 @@ class View extends \Magento\Catalog\Block\Category\View
     public function getSubcategories(): ?Collection
     {
         $category              = $this->getCurrentCategory();
-        $childrenCategoryIds   = $category->getChildrenCategories()->getAllIds();
+        $childrenCategoryIds   = explode(',', $category->getChildren());
         $additionalCategoryIds = $category->getData('additional_categories')
             ? array_map('trim', explode(',', $category->getData('additional_categories')))
             : [];


### PR DESCRIPTION
$category->getChildrenCategories() is no longer supported in Magento 2.4.2. Altered code to use the proper method $category->getChildren()