### PR TITLE
0.1.7 - Optionally hide tiling on filtered categories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "~7.0|~7.1|~7.2|~7.3",
+        "php": "^7.4|^8.0",
         "magento/framework": "^102.0|^103.0",
         "magento/module-catalog": "^103.0|^104.0"
     },

--- a/src/Model/Config.php
+++ b/src/Model/Config.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\CategoryTiling\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+final class Config
+{
+    private const CONFIG_SHOW_TILING_ON_FILTERED_CATEGORY_PAGE = 'elgentos_categorytiling/category/show_tiling_filtered';
+
+    private ScopeConfigInterface $scopeConfig;
+
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    public function showTilingOnFilteredCategoryPage(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::CONFIG_SHOW_TILING_ON_FILTERED_CATEGORY_PAGE,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+}

--- a/src/etc/acl.xml
+++ b/src/etc/acl.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+  <acl>
+    <resources>
+      <resource id="Magento_Backend::admin">
+        <resource id="Magento_Backend::stores">
+          <resource id="Magento_Backend::stores_settings">
+            <resource id="Magento_Config::config">
+              <resource id="Elgentos_CategoryTiling::config" title="Elgentos Category Tiling Config" sortOrder="100"/>
+            </resource>
+          </resource>
+        </resource>
+      </resource>
+    </resources>
+  </acl>
+</config>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <tab id="elgentos" translate="label" sortOrder="50">
+            <label>Elgentos</label>
+        </tab>
+        <section id="elgentos_categorytiling" translate="label" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Elgentos Category Tiling</label>
+            <tab>elgentos</tab>
+            <resource>Elgentos_CategoryTiling::config</resource>
+            <group id="category" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Category</label>
+                <field id="show_tiling_filtered" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" type="select">
+                    <label>Show tiling on filtered category pages</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <elgentos_categorytiling>
+            <category>
+                <show_tiling_filtered>1</show_tiling_filtered>
+            </category>
+        </elgentos_categorytiling>
+    </default>
+</config>


### PR DESCRIPTION
On filtered category pages, hide the tiling if this is set in config.

This update also opens the door for PHP 8 support.