### PR TITLE
fix to also hide tiling

### DIFF
--- a/src/Block/Category/View.php
+++ b/src/Block/Category/View.php
@@ -126,6 +126,12 @@ class View extends \Magento\Catalog\Block\Category\View
      */
     public function showTiling(): bool
     {
+        if ($this->config->showTilingOnFilteredCategoryPage() === false
+            && $this->isFilteredRequest()
+        ) {
+            return false;
+        }
+        
         return in_array(
             $this->getCurrentCategory()->getDisplayMode(),
             [


### PR DESCRIPTION
The intention was to hide the (static) cms block as also the tiling. In version 0.1.7 we only hide the (static) cms block and not the tiling. With this fix both are hidden 😄 